### PR TITLE
Fixed date type to string

### DIFF
--- a/src/main/types.js
+++ b/src/main/types.js
@@ -42,7 +42,7 @@ export class TypeConverter {
 
   static i64Mappings = {
     Long: 'Long',
-    Date: 'Date'
+    Date: 'string'
   };
 
   transformName: string => string;


### PR DESCRIPTION
This resolves https://github.com/uber/thrift2flow/issues/15 which brought up that thrift sends down Dates as strings, not actual Date objects. We should properly represent that value as a string in the flow output. There currently is no way to say it's specifically an ISO 8601 string so a string should be fine.

Example input:
```
typedef i64 (js.type = "Date") DateTime
struct LinkingRequest {
    0: optional DateTime  requestTime
}
```

Old output:
```
export type DateTimeType = Date;
export type LinkingRequestType = {|
  requestTime?: DateTimeType,
|};
```

New output:
```
export type DateTimeType = string;
export type LinkingRequestType = {|
  requestTime?: DateTimeType,
|};
```