### PR TITLE
Fixed issue when long is defined in typedef

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thrift2flow",
-  "version": "0.4.1",
+  "version": "0.4.3",
   "description": "Convert Thrift definitions to Flowtype declarations",
   "homepage": "https://github.com/uber-node/thrift2flow",
   "bugs": {
@@ -24,13 +24,15 @@
     "thrift2flow": "lib/index.js"
   },
   "scripts": {
-    "build": "babel src/main -d lib --source-maps",
     "build-test": "babel src -d dist-test --source-maps",
-    "test": "npm run build-test && node dist-test/test/index.spec.js",
+    "build": "babel src/main -d lib --source-maps",
     "check": "npm run prettier && npm run lint && npm run test",
-    "prettier": "prettier --single-quote --bracket-spacing false --parser flow --tab-width 2 --print-width 100 --write \"{src,test}/**/*.js\"",
+    "debug": "node --nolazy --inspect-brk=9229 lib/index.js",
+    "download-typedefs": "mkdir -p typedefs && curl -o typedefs/flowResult.js https://raw.githubusercontent.com/facebook/flow/master/tsrc/flowResult.js",
     "lint": "flow check && eslint src",
-    "download-typedefs": "mkdir -p typedefs && curl -o typedefs/flowResult.js https://raw.githubusercontent.com/facebook/flow/master/tsrc/flowResult.js"
+    "prepare": "npm run build",
+    "prettier": "prettier --single-quote --bracket-spacing false --parser flow --tab-width 2 --print-width 100 --write \"{src,test}/**/*.js\"",
+    "test": "npm run build-test && node dist-test/test/index.spec.js"
   },
   "engines": {
     "node": ">=6.10",

--- a/src/main/convert.js
+++ b/src/main/convert.js
@@ -173,9 +173,9 @@ export class ThriftFileConverter {
   getImportAbsPaths = () => Object.keys(this.thrift.idls).map(p => path.resolve(p));
 
   isLongDefined = () => {
-    for (let struct of this.thriftAstDefinitions) {
-      if (struct.type === "Struct") {
-        for (let field of struct.fields) {
+    for (let astNode of this.thriftAstDefinitions) {
+      if (astNode.type === "Struct") {
+        for (let field of astNode.fields) {
           if (field.valueType == null || field.valueType.annotations == null) {
             continue;
           }
@@ -184,8 +184,12 @@ export class ThriftFileConverter {
             return true;
           }
         }
-      } else if (struct.type === "Typedef") {
-        if (struct.valueType.annotations["js.type"] === "Long") {
+      } else if (astNode.type === "Typedef") {
+        if (astNode.valueType == null || astNode.valueType.annotations == null) {
+          continue;
+        }
+
+        if (astNode.valueType.annotations["js.type"] === "Long") {
           return true;
         }
       }

--- a/src/main/convert.js
+++ b/src/main/convert.js
@@ -174,15 +174,18 @@ export class ThriftFileConverter {
 
   isLongDefined = () => {
     for (let struct of this.thriftAstDefinitions) {
-      if (struct.type !== "Struct") {
-        continue;
-      }
-      for (let field of struct.fields) {
-        if (field.valueType == null || field.valueType.annotations == null) {
-          continue;
-        }
+      if (struct.type === "Struct") {
+        for (let field of struct.fields) {
+          if (field.valueType == null || field.valueType.annotations == null) {
+            continue;
+          }
 
-        if (field.valueType.annotations["js.type"] === "Long") {
+          if (field.valueType.annotations["js.type"] === "Long") {
+            return true;
+          }
+        }
+      } else if (struct.type === "Typedef") {
+        if (struct.valueType.annotations["js.type"] === "Long") {
           return true;
         }
       }


### PR DESCRIPTION
Resolves issue when defining typedefs at the top of the file such as
```
typedef i64 (js.type = "Long") Points
```
Wouldn't import the Long library thus resulting in a build failure