### PR TITLE
Update enum type generation to use unions of enum keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,7 @@
 /.idea
 /coverage
 /.vscode
+/test-output
+
 yarn-error.log
 yarn.lock

--- a/.npmignore
+++ b/.npmignore
@@ -3,4 +3,4 @@
 /typedefs
 /.idea
 /coverage
-test-output/**/*
+/test-output

--- a/.npmignore
+++ b/.npmignore
@@ -3,3 +3,4 @@
 /typedefs
 /.idea
 /coverage
+test-output/**/*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thrift2flow",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "description": "Convert Thrift definitions to Flowtype declarations",
   "homepage": "https://github.com/uber-node/thrift2flow",
   "bugs": {
@@ -24,6 +24,7 @@
     "thrift2flow": "lib/index.js"
   },
   "scripts": {
+    "clean-test-output": "git clean -Xdf test-output/",
     "build-test": "babel src -d dist-test --source-maps",
     "build": "babel src/main -d lib --source-maps",
     "check": "npm run prettier && npm run lint && npm run test",
@@ -32,7 +33,8 @@
     "lint": "flow check && eslint src",
     "prepare": "npm run build",
     "prettier": "prettier --single-quote --bracket-spacing false --parser flow --tab-width 2 --print-width 100 --write \"{src,test}/**/*.js\"",
-    "test": "npm run build-test && node dist-test/test/index.spec.js"
+    "test": "npm run build-test && node dist-test/test/index.spec.js",
+    "test-keep-output": "npm run build-test && KEEP_TEST_OUTPUT=true node dist-test/test/index.spec.js"
   },
   "engines": {
     "node": ">=6.10",
@@ -45,6 +47,7 @@
     "prettier": "^1.3.1",
     "source-map-support": "^0.4.15",
     "thriftrw": "^3.11.0",
+    "uuid": "^3.3.2",
     "yargs": "^8.0.1"
   },
   "devDependencies": {
@@ -64,6 +67,6 @@
     "flow-bin": "^0.65.0",
     "fs-extra": "^4.0.3",
     "tape": "^4.6.3",
-    "tmp": "0.0.31"
+    "tmp": "^0.0.33"
   }
 }

--- a/src/main/convert.js
+++ b/src/main/convert.js
@@ -106,18 +106,28 @@ export class ThriftFileConverter {
   generateTypedef = (def: Typedef) =>
     `export type ${this.transformName(def.id.name)} = ${this.types.convert(def.valueType)};`;
 
+  generateEnumUnion = (def: Enum) => {
+    return def.definitions
+      .map((d, index) => `"${d.id.name}"`).join(' | ');
+  };
+
+  generateEnumType = (def: Enum) => {
+    return `export type ${this.transformName(def.id.name)} = ${this.generateEnumUnion(def)};`;
+  };
+
   generateEnumMap = (def: Enum) => {
-    const header = `{`;
+    const header = '{';
     const values = def.definitions
       .map((d, index) => `  "${d.id.name}": ${d.value ? d.value.value : index},`)
       .join('\n');
-    const footer = `}`;
+    const footer = '}';
 
-    return [header, values, footer].join('\n');
+    const mapDefinition = [header, values, footer].join('\n');
+    return `export const ${def.id.name}ValueMap = ${mapDefinition};`;
   };
 
   generateEnum = (def: Enum) => {
-    return `export const ${this.transformName(def.id.name)} = ${this.generateEnumMap(def)};`;
+    return `${this.generateEnumType(def)}\n${this.generateEnumMap(def)}`;
   };
 
   generateConst = (def: Const) => {
@@ -154,7 +164,7 @@ export class ThriftFileConverter {
   isOptional = (field: Field) => field.optional;
 
   generateImports = () => {
-    let generatedImports = this.getImportAbsPaths()
+    const generatedImports = this.getImportAbsPaths()
       .filter(p => p !== this.thriftPath)
       .map(p =>
         path.join(
@@ -166,30 +176,30 @@ export class ThriftFileConverter {
       .map(relpath => `import * as ${path.basename(relpath)} from '${relpath}.js';`);
 
       if (this.isLongDefined()) {
-        generatedImports.push('import Long from \'long\'')
+        generatedImports.push('import Long from \'long\'');
       }
       return generatedImports.join('\n');
     }
   getImportAbsPaths = () => Object.keys(this.thrift.idls).map(p => path.resolve(p));
 
   isLongDefined = () => {
-    for (let astNode of this.thriftAstDefinitions) {
-      if (astNode.type === "Struct") {
-        for (let field of astNode.fields) {
+    for (const astNode of this.thriftAstDefinitions) {
+      if (astNode.type === 'Struct') {
+        for (const field of astNode.fields) {
           if (field.valueType == null || field.valueType.annotations == null) {
             continue;
           }
 
-          if (field.valueType.annotations["js.type"] === "Long") {
+          if (field.valueType.annotations['js.type'] === 'Long') {
             return true;
           }
         }
-      } else if (astNode.type === "Typedef") {
+      } else if (astNode.type === 'Typedef') {
         if (astNode.valueType == null || astNode.valueType.annotations == null) {
           continue;
         }
 
-        if (astNode.valueType.annotations["js.type"] === "Long") {
+        if (astNode.valueType.annotations['js.type'] === 'Long') {
           return true;
         }
       }

--- a/src/main/types.js
+++ b/src/main/types.js
@@ -71,7 +71,7 @@ export class TypeConverter {
     this.transformName(t.name);
 
   enumType = (thriftValueType: BaseType) =>
-    this.isEnum(thriftValueType) && `$Keys<typeof ${this.transformName(thriftValueType.name)}>`;
+    this.isEnum(thriftValueType) && this.transformName(thriftValueType.name);
 
   arrayType = (thriftValueType: BaseType) =>
     (thriftValueType instanceof ListType || thriftValueType instanceof SetType) &&

--- a/src/test/enums.spec.js
+++ b/src/test/enums.spec.js
@@ -50,12 +50,21 @@ struct MyStruct {
       // language=JavaScript
       'index.js': `
 // @flow
-import type {MyStructXXX,EnumTypedefXXX} from './types';
+import {MyEnumValueMap} from './types';
+import type {MyStructXXX,EnumTypedefXXX,MyEnumXXX} from './types';
 
-function go(s : MyStructXXX, t: EnumTypedefXXX) {
-  const values : string[] = [s.f_MyEnum, s.f_EnumTypedef, t];
-  return [values];
+const ok: MyEnumXXX = 'OK';
+const error: MyEnumXXX = 'ERROR';
+
+const struct: MyStructXXX = {
+  f_MyEnum: ok,
+  f_EnumTypedef: error,
 }
+
+const okFromMap: 1 = MyEnumValueMap.OK;
+const errorFromMap: 2 = MyEnumValueMap.ERROR;
+
+const t: EnumTypedefXXX = ok;
 `
     },
     (t: Test, r: FlowResult) => {
@@ -65,9 +74,7 @@ function go(s : MyStructXXX, t: EnumTypedefXXX) {
   )
 );
 
-test(
-  'enums values',
-  flowResultTest(
+test('enums with errors', flowResultTest(
     {
       // language=thrift
       'types.thrift': `
@@ -86,51 +93,23 @@ struct MyStruct {
       // language=JavaScript
       'index.js': `
 // @flow
-import type {MyStructXXX,EnumTypedefXXX} from './types';
-import {MyEnumXXX} from './types';
+import type {MyStructXXX,EnumTypedefXXX,MyEnumXXX} from './types';
 
-function go(s : MyStructXXX, t: $Values<typeof MyEnumXXX>, k: $Keys<typeof MyEnumXXX>) {
-  const values : number[] = [MyEnumXXX[s.f_MyEnum], MyEnumXXX[s.f_EnumTypedef], t];
-  const keys : $Keys<typeof MyEnumXXX> = 'OK';
-  return [values, keys];
+const ok: MyEnumXXX = 'NOT CORRECT';
+const error: MyEnumXXX = null;
+
+const struct: MyStructXXX = {
+  f_MyEnum: 'NOT CORRECT',
+  f_EnumTypedef: null,
 }
+
+const t: EnumTypedefXXX = 'NOT CORRECT';
 `
     },
     (t: Test, r: FlowResult) => {
-      t.deepEqual(r.errors, []);
+      t.equal(r.errors.length, 5);
       t.end();
-    },
-    'XXX',
-    true
+    }
   )
-);
-
-test(
-  'enums map',
-  flowResultTest(
-    {
-      // language=thrift
-      'types.thrift': `
-enum MyEnum {
-  OK = 1
-  ERROR = 2
-}
-`,
-      // language=JavaScript
-      'index.js': `
-// @flow
-import {MyEnumXXX} from './types';
-
-function go() {
-  return [MyEnumXXX.OK];
-}
-`
-    },
-    (t: Test, r: FlowResult) => {
-      t.deepEqual(r.errors, []);
-      t.end();
-    },
-    'XXX',
-    true
-  )
-);
+)
+;

--- a/src/test/util.js
+++ b/src/test/util.js
@@ -30,10 +30,10 @@ import fs from 'fs-extra';
 
 import {exec} from 'child_process';
 import type {Test} from 'tape';
-
-import tmp from 'tmp';
+import uuid from 'uuid/v4';
 
 import {ThriftFileConverter} from '../main/convert';
+
 
 export const flowResultTest = (
   files: {[string]: string},
@@ -41,7 +41,8 @@ export const flowResultTest = (
   suffix: string = 'XXX',
   withsource: boolean = true
 ) => (t: Test) => {
-  const root = tmp.dirSync().name;
+  const root = path.resolve('test-output/', uuid());
+  fs.mkdirSync(root);
   const paths = Object.keys(files);
   paths.forEach(p => fs.writeFileSync(path.resolve(root, p), files[p]));
   paths
@@ -59,7 +60,13 @@ export const flowResultTest = (
 ./typedefs`
   );
   fs.copy('./typedefs/', path.resolve(root, 'typedefs'));
-  exec('flow check --json', {cwd: root}, (err, stdout, stderr) =>
-    testFn(t, JSON.parse(typeof stdout === 'string' ? stdout : stdout.toString()))
-  );
+  exec('flow check --json', {cwd: root}, (err, stdout, stderr) => {
+    testFn(t, JSON.parse(typeof stdout === 'string' ? stdout : stdout.toString()));
+    // This can be useful when debugging generated code
+    // Run `npm run clean-test-output` to clean up latter
+    // eslint-disable-next-line no-process-env
+    if (!process.env.KEEP_TEST_OUTPUT) {
+      fs.removeSync(root);
+    }
+  });
 };


### PR DESCRIPTION
Thrift enums should be referenced in js by their string equivalents. This updates the enum type generation to reflect this by generating type unions of the possible enum strings. It leaves the previous method of enum type generation exported under a different namespace.